### PR TITLE
feat: Add netlify.toml to configure build settings

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,15 @@
+[build]
+  base = "Shriramrajya-main"
+  command = "npm run build:client"
+  functions = "netlify/functions"
+  publish = "dist/spa"
+
+[functions]
+  external_node_modules = ["express"]
+  node_bundler = "esbuild"
+
+[[redirects]]
+  force = true
+  from = "/api/*"
+  status = 200
+  to = "/.netlify/functions/api/:splat"


### PR DESCRIPTION
### Purpose

The user encountered a Netlify build failure because the `package.json` file could not be found in the root directory. The goal of this pull request is to fix the build error by providing the correct project structure configuration to Netlify.

### Code changes

A `netlify.toml` file has been created in the project root. This file specifies the following configurations:

- **Build settings**: The `base` directory is set to `Shriramrajya-main`, the `command` for building the client is defined, and the `publish` and `functions` directories are specified.
- **Functions**: Configuration for external Node.js modules and the Node.js bundler.
- **Redirects**: A redirect rule is added to proxy API requests to the appropriate serverless function.

<!-- FUSION_KEEP_START -->
<!-- FUSION_KEEP_END -->

🔗 [Edit in Builder.io](https://builder.io/app/projects/38867bb7fcfd4df3bceefe448aa1809b/curry-home)

👀 [Preview Link](https://38867bb7fcfd4df3bceefe448aa1809b-curry-home.projects.builder.my/)To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`



<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>38867bb7fcfd4df3bceefe448aa1809b</projectId>-->
<!--<branchName>curry-home</branchName>-->